### PR TITLE
2022-05-02

### DIFF
--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_Attack.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_Attack.cpp
@@ -21,7 +21,8 @@ EBTNodeResult::Type UBTTaskNode_Attack::ExecuteTask(UBehaviorTreeComponent& Owne
     auto AICharacter = Cast<AAICharacter>(OwnerComp.GetAIOwner()->GetPawn());
     if (nullptr == AICharacter)
         return EBTNodeResult::Failed;
-
+    if (AICharacter->bIsDie)
+        return EBTNodeResult::Failed;
 
     AICharacter->Attack();
     IsAttacking = true;

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_Farming.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_Farming.cpp
@@ -20,6 +20,9 @@ EBTNodeResult::Type UBTTaskNode_Farming::ExecuteTask(UBehaviorTreeComponent& Own
 	auto ControllingPawn = OwnerComp.GetAIOwner()->GetPawn();
 
 	auto ai = Cast<AAICharacter>(ControllingPawn);
+
+	if (ai->bIsDie)
+		return EBTNodeResult::Failed;
 	ai->GetFruits();
 
 	//int FruitAmount = ai->mInventory->mSlots[ai->SelectedHotKeySlotNum].Amount;

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_FindTreePos.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_FindTreePos.cpp
@@ -96,6 +96,7 @@ EBTNodeResult::Type UBTTaskNode_FindTreePos::ExecuteTask(UBehaviorTreeComponent&
 	
 	AAICharacter* ai = Cast<AAICharacter>(OwnerComp.GetAIOwner()->GetPawn());
 
+	if (ai->bIsDie) EBTNodeResult::Failed;
 	if (!ai->bAttacking)
 		return EBTNodeResult::Succeeded;
 	return EBTNodeResult::Failed;

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_GoToTheTree.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_GoToTheTree.cpp
@@ -28,6 +28,7 @@ EBTNodeResult::Type UBTTaskNode_GoToTheTree::ExecuteTask(UBehaviorTreeComponent&
 
 	AAICharacter* ai = Cast<AAICharacter>(ControllingPawn);
 
+	if (ai->bIsDie) EBTNodeResult::Failed;
 	//UE_LOG(LogTemp, Warning, TEXT("%s"), *TreePos.ToString());
 	if (ai->bIsUndertheTree)
 		return EBTNodeResult::Succeeded;

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_TurnToTarget.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BTTaskNode_TurnToTarget.cpp
@@ -21,6 +21,8 @@ EBTNodeResult::Type UBTTaskNode_TurnToTarget::ExecuteTask(UBehaviorTreeComponent
 	{
 		return EBTNodeResult::Failed;
 	}
+
+	if (AICharacter->bIsDie) EBTNodeResult::Failed;
 	auto Target = Cast<AMyCharacter>(OwnerComp.GetBlackboardComponent()->GetValueAsObject(AAIController_Custom::TargetKey));
 	if (nullptr == Target)
 		return EBTNodeResult::Failed;

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/Network.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/Network.cpp
@@ -565,6 +565,8 @@ void Network::process_packet(unsigned char* p)
 
 			mMyCharacter->DisableInput(mMyCharacter->GetWorld()->GetFirstPlayerController());
 			mMyCharacter->bIsDie = true;
+			mMyCharacter->bAttacking = false;
+			mMyCharacter->bLMBDown = false;
 			mMyCharacter->SetActorEnableCollision(false);
 
 			mMyCharacter->mInventory->mMainWidget->ShowRespawnWidget();
@@ -1020,6 +1022,8 @@ void Network::process_Aipacket(int client_id, unsigned char* p)
 		if (packet->id == PacketOwner->c_id) {
 
 			PacketOwner->bIsDie = true;
+			//PacketOwner->bAttacking = false;
+			//PacketOwner->OnAttackEnd.Broadcast();
 			PacketOwner->SetActorEnableCollision(false);
 		}
 		else if (packet->id < MAX_USER)

--- a/Server/FPP_Server/Source/Game/Network/Network.cpp
+++ b/Server/FPP_Server/Source/Game/Network/Network.cpp
@@ -433,7 +433,7 @@ void process_packet(int client_id, unsigned char* p)
 		{
 			character->mSlot[packet->itemSlotNum].amount -= 1;
 			cout << client_id << "번째 유저의" << packet->itemSlotNum << "번째 슬롯 아이템 1개 감소 현재 개수:" << character->mSlot[packet->itemSlotNum].amount << endl;
-			FPP_LOG("[%d]유저 [%d]번째 슬롯 아이템 1개 감소 ", client_id, packet->itemSlotNum);
+			FPP_LOG("[%d]유저 [%d]번째 슬롯 아이템 1개 감소 현재 개수: %d", client_id, packet->itemSlotNum, character->mSlot[packet->itemSlotNum].amount);
 		}
 		else {
 			FPP_LOG("[%d]번째 유저가 %d 번째 슬롯의 아이템이 없는데 사용하려고 시도함.", client_id, packet->itemSlotNum);
@@ -509,6 +509,7 @@ void process_packet(int client_id, unsigned char* p)
 
 		if (!punnet->canHarvest)
 			break;
+		punnet->canHarvest = false;
 
 		cout << "과일 받았습니다(과일상자)" << endl;
 		if (punnet->_ftype == FRUITTYPE::T_HEAL)
@@ -518,17 +519,18 @@ void process_packet(int client_id, unsigned char* p)
 		else if (punnet->_ftype == FRUITTYPE::T_GREENONION)
 		{
 			character->UpdateInventorySlotAtIndex(2, punnet->_ftype, 1);
-			send_update_inventory_packet(client_id, 2);
 		}
 		else if (punnet->_ftype == FRUITTYPE::T_CARROT)
 		{
 			character->UpdateInventorySlotAtIndex(2, punnet->_ftype, 1);
-			send_update_inventory_packet(client_id, 2);
+		}
+		else if (punnet->_ftype == FRUITTYPE::T_BANANA)
+		{
+			character->UpdateInventorySlotAtIndex(4, punnet->_ftype, 5);
 		}
 		else
 		{
 			character->UpdateInventorySlotAtIndex(3, punnet->_ftype, 5);
-			send_update_inventory_packet(client_id, 3);
 		}
 
 		
@@ -544,7 +546,6 @@ void process_packet(int client_id, unsigned char* p)
 				send_update_interstat_packet(other->_id, packet->obj_id, false, INTERACT_TYPE_PUNNET);
 			}
 		}
-		punnet->canHarvest = false;
 		break;
 	}
 	case CS_PACKET_USEITEM: {

--- a/Server/FPP_Server/Source/Game/Object/Character/Character.cpp
+++ b/Server/FPP_Server/Source/Game/Object/Character/Character.cpp
@@ -79,6 +79,8 @@ void Character::UpdateInventorySlotAtIndex(const int& index, FRUITTYPE itemcode,
 		slot.type = itemcode;
 		slot.amount = amount;
 	}
+
+	send_update_inventory_packet(_id, index);
 }
 
 void Character::Die()


### PR DESCRIPTION
작업자 : 이수민
작업내용 :
ai 죽고나서 움직이는 버그 수정, 플레이어 공격도중 죽었을때 공격계속하는 버그 수정.

bisDie로 죽음을 판별하기 때문에
단순하게 behavior tree에서 die가 true면 failed를 반환하여 btree가 일을 하지 못하도록 변경해서 버그를 수정했다.

또한 die패킷이 왔을 때, ui모드로 바뀌어서 LMBUP이 consume이 안되는것을 강제로 false로 바꿔주어, 계속 공격하는것을 멈추게한다.
player는 이렇게 수정을 했는데, AI도 동일하게 하려했으나 player와는 조금 다른것 같아서 주석을 쳐놓았다.

OnAttackEnd.Broadcast()를 주석처리 해놓았는데, 풀었을때 제대로 된다면 풀면 될 것 같다.