### PR TITLE
2022-05-05

### DIFF
--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/MyCharacter.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/MyCharacter.cpp
@@ -801,7 +801,7 @@ void AMyCharacter::Throw()
 	else
 	{
 		FTransform SocketTransform = GetMesh()->GetSocketTransform("BombSocket");
-
+		
 		FRotator CameraRotate = FollowCamera->GetComponentRotation();
 		CameraRotate.Pitch += 14;
 		FTransform trans(CameraRotate.Quaternion(), SocketTransform.GetLocation());

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/Network.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/Network.cpp
@@ -461,20 +461,27 @@ void Network::process_packet(unsigned char* p)
 		{
 			mOtherCharacter[id]->GetMesh()->SetVisibility(true);
 			mOtherCharacter[id]->c_id = packet->id;
+			mMyCharacter->mInventory->mMainWidget->mScoreWidget->ScoreBoard.push_back(ScoreInfo(mOtherCharacter[id]));
+			mMyCharacter->mInventory->mMainWidget->mScoreWidget->UpdateRank();
 		}
 		else {
 			FName path = TEXT("Blueprint'/Game/Character/BP_MyCharacter.BP_MyCharacter_C'"); //_C를 꼭 붙여야 된다고 함.
 			UClass* GeneratedInventoryBP = Cast<UClass>(StaticLoadObject(UClass::StaticClass(), NULL, *path.ToString()));
-			FTransform trans(FQuat(packet->rx, packet->ry, packet->rz, packet->rw), FVector(packet->x, packet->y, packet->z));
+			FTransform trans(FQuat(packet->rx, packet->ry, packet->rz, packet->rw), FVector(10020, 12760, 300));
 			auto mc = mMyCharacter->GetWorld()->SpawnActorDeferred<AMyCharacter>(GeneratedInventoryBP, trans);
-			mc->SpawnDefaultController();
-			mc->AutoPossessPlayer = EAutoReceiveInput::Disabled;
-			mc->FinishSpawning(trans);
-			mOtherCharacter[id] = mc;
-			mOtherCharacter[id]->c_id = packet->id;
+			if (nullptr != mc)
+			{
+				mc->SpawnDefaultController();
+				mc->AutoPossessPlayer = EAutoReceiveInput::Disabled;
+				mc->FinishSpawning(trans);
+				mOtherCharacter[id] = mc;
+				mOtherCharacter[id]->GetMesh()->SetVisibility(true);
+				mOtherCharacter[id]->c_id = packet->id;
+				mMyCharacter->mInventory->mMainWidget->mScoreWidget->ScoreBoard.push_back(ScoreInfo(mOtherCharacter[id]));
+				mMyCharacter->mInventory->mMainWidget->mScoreWidget->UpdateRank();
+			}
 		}
-		mMyCharacter->mInventory->mMainWidget->mScoreWidget->ScoreBoard.push_back(ScoreInfo(mOtherCharacter[id]));
-		mMyCharacter->mInventory->mMainWidget->mScoreWidget->UpdateRank();
+
 		break;
 	}
 	case SC_PACKET_REMOVE_OBJECT: {
@@ -951,9 +958,29 @@ void Network::process_Aipacket(int client_id, unsigned char* p)
 
 		if (USER_START <= id && id < MAX_USER)
 		{
-			mOtherCharacter[id]->GetMesh()->SetVisibility(true);
-			mOtherCharacter[id]->c_id = packet->id;
-			mOtherCharacter[id]->s_connected = true;
+			if (nullptr != mOtherCharacter[id])
+			{
+				mOtherCharacter[id]->GetMesh()->SetVisibility(true);
+				mOtherCharacter[id]->c_id = packet->id;
+				mOtherCharacter[id]->s_connected = true;
+			}
+			else {
+				FName path = TEXT("Blueprint'/Game/Character/BP_MyCharacter.BP_MyCharacter_C'"); //_C를 꼭 붙여야 된다고 함.
+				UClass* GeneratedInventoryBP = Cast<UClass>(StaticLoadObject(UClass::StaticClass(), NULL, *path.ToString()));
+				FTransform trans(FQuat(packet->rx, packet->ry, packet->rz, packet->rw), FVector(10020, 12760, 300));
+				auto mc = mMyCharacter->GetWorld()->SpawnActorDeferred<AMyCharacter>(GeneratedInventoryBP, trans);
+				if (nullptr != mc)
+				{
+					mc->SpawnDefaultController();
+					mc->AutoPossessPlayer = EAutoReceiveInput::Disabled;
+					mc->FinishSpawning(trans);
+					mOtherCharacter[id] = mc;
+					mOtherCharacter[id]->GetMesh()->SetVisibility(true);
+					mOtherCharacter[id]->c_id = packet->id;
+					mOtherCharacter[id]->s_connected = true;
+				}
+			}
+
 		}
 		else {
 			UE_LOG(LogTemp, Error, TEXT("UnExpected ID Come To PACKET_PUT_OBJECT id: %d"), id);

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/Network.h
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/Network.h
@@ -59,6 +59,7 @@ public:
 	};
 	class AMyCharacter* mMyCharacter;
 	class AAICharacter* mAiCharacter[8];
+	UPROPERTY()
 	class AMyCharacter* mOtherCharacter[MAX_USER];
 	class ATree* mTree[TREE_CNT];
 	class APunnet* mPunnet[PUNNET_CNT];

--- a/Server/FPP_Server/Source/Game/Object/Character/Character.cpp
+++ b/Server/FPP_Server/Source/Game/Object/Character/Character.cpp
@@ -49,6 +49,8 @@ void Character::recvPacket()
 		int err = WSAGetLastError();
 		if (ERROR_IO_PENDING != err)
 		{
+			_state = Character::STATE::ST_FREE;
+			closesocket(_socket);
 			error_display(err);
 		}
 	}


### PR DESCRIPTION
작업자 : 이수민
작업내용 :
여태 말 도 안됐던 버그 해결.
자꾸만 캐릭터 스폰이 안 되고, 프로그램이 터져서
GC(가비지콜렉터) 문제였나 싶었는데

생각보다 엄청나게 단순한 이유로 인해서 버그가 터지는 것 이었다.

캐릭터 스폰을 해줄 때 패킷을 받아 패킷의 위치(0,0,0) 에서 스폰을 해주게 되는데
이 경우 캐릭터가 지형에 껴서 collision 문제 때문에 스폰이 안되는 것 이었다.

LogSpawn : Warning : SpawnActor failed because of collision at the spawn location [ X= 0.000 Y = 0.000 Z= 0.000] for [BP_MyCharacter_C] 라고 나온다....

뭔가 이상할땐 로그를 한번 봐야할 듯.