### PR TITLE
2022-07-05(자잘한 버그 수정)

### DIFF
--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BaseCharacter.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/BaseCharacter.cpp
@@ -20,6 +20,7 @@ ABaseCharacter::ABaseCharacter()
 	, bStepBanana(false)
 	, bHitbyFruit(false)
 	, CharacterName(FString(""))
+	, s_socket(INVALID_SOCKET)
 	, l_socket(INVALID_SOCKET)
 	, l_prev_size(0)
 {

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/HealSpawner.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/HealSpawner.cpp
@@ -22,12 +22,15 @@ void AHealSpawner::OnOverlapBegin(UPrimitiveComponent* OverlappedComponent, AAct
 		ABaseCharacter* player = Cast<ABaseCharacter>(OtherActor);
 		if (player && CanHarvest)
 		{
-			CanHarvest = false;
-			send_getfruits_healspawner_packet(player->s_socket, HealSpanwerId);
+            if (INVALID_SOCKET != player->s_socket)
+            {
+                CanHarvest = false;
+                send_getfruits_healspawner_packet(player->s_socket, HealSpanwerId);
 
-            player->bIsUndertheHealSpawner = true;
+                player->bIsUndertheHealSpawner = true;
 
-            UE_LOG(LogTemp, Warning, TEXT("Heal Overlap!"));
+                UE_LOG(LogTemp, Warning, TEXT("Heal Overlap!"));
+            }
 		}
     }
 }
@@ -83,6 +86,7 @@ void AHealSpawner::HarvestFruit()
 	}
 
     CanHarvest = false;
+    UE_LOG(LogTemp, Warning, TEXT("Heal Harvested!"));
 
 }
 // Called when the game starts or when spawned

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/InGameAiLv.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/InGameAiLv.cpp
@@ -8,6 +8,7 @@
 
 void AInGameAiLv::BeginPlay() {
 
+	Network::GetNetwork()->bLevelOpenTriggerEnabled = false;	//∑π∫ß Ω√¿€µ∆¿∏¥œ ∆Æ∏Æ∞≈ ≤®¡‹.
 	ConnAi();
 }
 

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/InGameLv.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/InGameLv.cpp
@@ -9,6 +9,7 @@
 
 void AInGameLv::BeginPlay() {
 
+	Network::GetNetwork()->bLevelOpenTriggerEnabled = false;	//레벨 시작됐으니 트리거 꺼줌.
 	/*
 	
 	1. Loading Widget을 띄우고

--- a/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/InLobbyLv.cpp
+++ b/FruitsPangPang/FruitsPangPang/Source/FruitsPangPang/InLobbyLv.cpp
@@ -8,6 +8,7 @@
 
 void AInLobbyLv::BeginPlay() {
 
+	Network::GetNetwork()->bLevelOpenTriggerEnabled = false;	//레벨 시작됐으니 트리거 꺼줌.
 	/*
 
 	1. 캐릭터를 스폰하고 Network mMyCharacter에 연결


### PR DESCRIPTION
작업자 : 이수민
작업내용 :
힐팩 안먹어지는 버그 및/ InGAme에서 Editor Simulate Stop시, 로그인 화면 안나오는 버그 수정

1. 힐팩이 Harvest되는 경우는 2가지이다. 몸으로 부딪히거나, 상대방이 먹어서 Harvest Packet이 오거나
그런데 상대방이 먹었을때 Harvest Packet이 오기 전에 몸으로 부딪혀서 클라 자체판단때문에 로직이 꼬여버린 것이었다. 내 기준으로 상대방은 Socket값이 초기화값(INAVLID_SOCKET) 이기 때문에 INVALID_SOCKET이면 클라 자체계산처리를 ignore해줌으로써 수정해주었다.

2. leveltrigger는 level이 바뀔때에만 유지이고, level이 바뀌었다면 다시 false로 바꾸어주도록 해서 버그수정.